### PR TITLE
Added metadata context to connection string

### DIFF
--- a/Fabric.IdentityProviderSearchService/Web.config
+++ b/Fabric.IdentityProviderSearchService/Web.config
@@ -4,6 +4,9 @@
   https://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
+  <connectionStrings>
+    <add name="MetadataContext" connectionString="Server=localhost;Database=EDWAdmin;Integrated Security=SSPI;Application Name=MetadataService;" providerName="System.Data.SqlClient" />
+  </connectionStrings>
   <system.web>
     <compilation debug="true" targetFramework="4.6.1"/>
     <httpRuntime targetFramework="4.6.1"/>


### PR DESCRIPTION
When the value is in the web config, then it will be used in the installer.