### PR TITLE
Only try to decrypt if ClientAppSettings is not null

### DIFF
--- a/Fabric.IdentityProviderSearchService/Configuration/IdentityProviderSearchServiceConfigurationProvider.cs
+++ b/Fabric.IdentityProviderSearchService/Configuration/IdentityProviderSearchServiceConfigurationProvider.cs
@@ -22,7 +22,7 @@ namespace Fabric.IdentityProviderSearchService.Configuration
 
         private void DecryptEncryptedValues(IAppConfiguration appConfig)
         {
-            if(_encryptionCertificateSettings != null)
+            if(_encryptionCertificateSettings != null && appConfig.AzureActiveDirectoryClientSettings.ClientAppSettings != null)
             {
                 foreach (var setting in appConfig.AzureActiveDirectoryClientSettings.ClientAppSettings)
                 {


### PR DESCRIPTION
Fix issue idpss would 500 on startup if Azure ClientAppSettings was null and it tried to access those setting to decrypt