### PR TITLE
Update appsettings to have empty  EncryptionCertificateSettings

### DIFF
--- a/Fabric.IdentityProviderSearchService.IntegrationTests/ServiceTests/IdentityProviderSearchServiceConfigurationProviderTests.cs
+++ b/Fabric.IdentityProviderSearchService.IntegrationTests/ServiceTests/IdentityProviderSearchServiceConfigurationProviderTests.cs
@@ -35,7 +35,7 @@ namespace Fabric.IdentityProviderSearchService.IntegrationTests.ServiceTests
 
             // Assert
             Assert.NotNull(appConfig);
-            for (int i = 0; i <= count; i++)
+            for (int i = 0; i < count; i++)
             {
                 Assert.Equal(clientSecret, appConfig.AzureActiveDirectoryClientSettings.ClientAppSettings[i].ClientSecret);
             }
@@ -52,7 +52,7 @@ namespace Fabric.IdentityProviderSearchService.IntegrationTests.ServiceTests
         private string GetEncryptedAppSettings(RSA privateKey, string clientSecret, int appSettingsCount = 1)
         {
             var appSettingsList = new List<AzureClientApplicationSettings>();
-            for(int i = 0; i <= appSettingsCount; i++)
+            for(int i = 0; i < appSettingsCount; i++)
             {
                 appSettingsList.Add(new AzureClientApplicationSettings
                 {

--- a/Fabric.IdentityProviderSearchService/appsettings.json
+++ b/Fabric.IdentityProviderSearchService/appsettings.json
@@ -16,6 +16,9 @@
       "fabric/idprovider.searchusers"
     ]
   },
+  "EncryptionCertificateSettings": {
+    "EncryptionCertificateThumpprint": ""
+  },
   "AzureActiveDirectoryClientSettings": {
     "Authority": "https://login.microsoftonline.com/",
     "TokenEndpoint": "/oauth2/v2.0/token",


### PR DESCRIPTION
Was breaking trying to use a null valued EncryptionCertificateSettings on startup
Should kick out of decryption path if clientSecret is unencrypted/not set